### PR TITLE
add pre commit

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Получаем измененные файлы, которые будут коммититься
+FILES=$(git diff --name-only --cached -- "*.js" "*.ts" "*.jsx" "*.tsx")
+
+if [ "$FILES" != "" ]; then
+  npx prettier --config .prettierrc --check $FILES || exit 1
+  npx eslint --config eslint.config.js $FILES || exit 1
+  npx tsc --noEmit --project tsconfig.app.json
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "bookfast-club",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "preview": "vite preview",
     "lint:ts": "npx eslint \"**/*.{ts,tsx}\"",
     "lint:ts:fix": "npx eslint \"**/*.{ts,tsx}\"--fix",
-    "prettier:fix": "npx prettier . --write"
+    "prettier:fix": "npx prettier . --write",
+    "check-types": "tsc --noEmit --project tsconfig.app.json",
+    "prepare": "git config core.hooksPath .git-hooks || echo 'Not in a git repo'",
+    "postinstall": "chmod +x .git-hooks/pre-commit"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",


### PR DESCRIPTION
Добавил прекоммит-хук, который настраивается вместе с npm install.

Он работает на прекоммит-хуке от Git.

Сейчас есть проблема: tsc проверяет все файлы проекта, а не только изменённые. Если в будущем это станет слишком долгим, исправим, но с husky у нас было так же. Проблема связана с тем, что нельзя одновременно использовать параметр --project и передавать конкретные файлы.